### PR TITLE
Update XC query-spec to include all XC collection types

### DIFF
--- a/specimen/wildlife-sounds.dataset-config.xml
+++ b/specimen/wildlife-sounds.dataset-config.xml
@@ -164,7 +164,7 @@
                 <conditions>
                     <condition>
                         <field>collectionType</field>
-                        <operator>EQUALS</operator>
+                        <operator>STARTS_WITH_IC</operator>
                         <value>Wildlife sounds</value>
                     </condition>
                     <condition>


### PR DESCRIPTION
The previous update did not include multimedia. This update fixes that